### PR TITLE
Make generated `AMQPProperties` type serializable with serde

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -53,5 +53,9 @@ features = ["std"]
 version  = "^7.0"
 features = ["std"]
 
+[dependencies.serde]
+version  = "^1.0"
+features = ["derive"]
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/protocol/src/generated.rs
+++ b/protocol/src/generated.rs
@@ -1358,7 +1358,7 @@ pub mod basic {
         }
     }
     /// basic properties (Generated)
-    #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+    #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
     pub struct AMQPProperties {
         content_type: Option<ShortString>,
         content_encoding: Option<ShortString>,

--- a/protocol/src/generated.rs
+++ b/protocol/src/generated.rs
@@ -1358,7 +1358,7 @@ pub mod basic {
         }
     }
     /// basic properties (Generated)
-    #[derive(Clone, Debug, Default, PartialEq)]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct AMQPProperties {
         content_type: Option<ShortString>,
         content_encoding: Option<ShortString>,

--- a/protocol/src/protocol.rs
+++ b/protocol/src/protocol.rs
@@ -8,6 +8,7 @@ use nom::{
     combinator::{flat_map, map, map_opt},
     error::context,
 };
+use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, error, fmt, io::Write};
 
 #[cfg(feature = "codegen")]

--- a/protocol/templates/protocol.rs
+++ b/protocol/templates/protocol.rs
@@ -292,7 +292,7 @@ pub mod {{snake class.name}} {
     {{/each ~}}
     {{#if class.properties ~}}
     /// {{class.name}} properties (Generated)
-    #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+    #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
     pub struct AMQPProperties {
         {{#each class.properties as |property| ~}}
         {{snake property.name}}: Option<{{property.type}}>,

--- a/protocol/templates/protocol.rs
+++ b/protocol/templates/protocol.rs
@@ -292,7 +292,7 @@ pub mod {{snake class.name}} {
     {{/each ~}}
     {{#if class.properties ~}}
     /// {{class.name}} properties (Generated)
-    #[derive(Clone, Debug, Default, PartialEq)]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct AMQPProperties {
         {{#each class.properties as |property| ~}}
         {{snake property.name}}: Option<{{property.type}}>,


### PR DESCRIPTION
Hello!
This PR makes the `AMQPProperties` type in the `amq-protocol` crate serializable with serde. All the fields of that struct were already serializable and the `serde` crate was already pulled in by `amq-protocol-types`.

Thank you!