### PR TITLE
Add implementation for converting ShortString to String

### DIFF
--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -202,6 +202,12 @@ impl fmt::Display for ShortString {
     }
 }
 
+impl From<ShortString> for String {
+    fn from(value: ShortString) -> Self {
+        value.0
+    }
+}
+
 impl<'a> LongString {
     /// Get a reference to a LongString as &[u8]
     pub fn as_bytes(&'a self) -> &'a [u8] {


### PR DESCRIPTION
When integrating with other libraries it can be useful to get away from
protocol specific types especially for common types such as `String`.

Add an implementation for `From<ShortString> for String` to unwrap a
`ShortString` and get the original String back.
