### PR TITLE
parsing: fixed parsing frames with attributes contained dashes

### DIFF
--- a/protocol/src/frame/parsing.rs
+++ b/protocol/src/frame/parsing.rs
@@ -162,4 +162,25 @@ mod test {
             Ok((&[][..], AMQPFrame::Heartbeat(1)))
         );
     }
+
+    #[test]
+    fn test_parse_declare_queue_frame() {
+        let frame = AMQPFrame::Method(
+            1,
+            AMQPClass::Queue(queue::AMQPMethod::Declare(queue::Declare {
+                queue: "some_queue".into(),
+                passive: true,
+                durable: true,
+                exclusive: true,
+                auto_delete: true,
+                nowait: true,
+                arguments: Default::default(),
+            })),
+        );
+
+        let mut buffer = vec![0u8; 30];
+
+        assert!(gen_frame(&frame)(buffer.as_mut_slice().into()).is_ok());
+        assert_eq!(parse_frame(buffer.as_slice()), Ok((&[][..], frame)));
+    }
 }

--- a/protocol/src/generated.rs
+++ b/protocol/src/generated.rs
@@ -646,7 +646,7 @@ pub mod basic {
         let (i, _) = parse_short_uint.parse(i)?;
         let (i, queue) = parse_short_string.parse(i)?;
         let (i, consumer_tag) = parse_short_string.parse(i)?;
-        let (i, flags) = parse_flags(i, &["no-local", "no-ack", "exclusive", "nowait"])?;
+        let (i, flags) = parse_flags(i, &["no_local", "no_ack", "exclusive", "nowait"])?;
         let (i, arguments) = parse_field_table.parse(i)?;
         Ok((
             i,
@@ -998,7 +998,7 @@ pub mod basic {
     pub fn parse_get<I: ParsableInput>(i: I) -> ParserResult<I, Get> {
         let (i, _) = parse_short_uint.parse(i)?;
         let (i, queue) = parse_short_string.parse(i)?;
-        let (i, flags) = parse_flags(i, &["no-ack"])?;
+        let (i, flags) = parse_flags(i, &["no_ack"])?;
         Ok((
             i,
             Get {
@@ -3040,7 +3040,7 @@ pub mod exchange {
         let (i, kind) = parse_short_string.parse(i)?;
         let (i, flags) = parse_flags(
             i,
-            &["passive", "durable", "auto-delete", "internal", "nowait"],
+            &["passive", "durable", "auto_delete", "internal", "nowait"],
         )?;
         let (i, arguments) = parse_field_table.parse(i)?;
         Ok((
@@ -3135,7 +3135,7 @@ pub mod exchange {
     pub fn parse_delete<I: ParsableInput>(i: I) -> ParserResult<I, Delete> {
         let (i, _) = parse_short_uint.parse(i)?;
         let (i, exchange) = parse_short_string.parse(i)?;
-        let (i, flags) = parse_flags(i, &["if-unused", "nowait"])?;
+        let (i, flags) = parse_flags(i, &["if_unused", "nowait"])?;
         Ok((
             i,
             Delete {
@@ -3527,7 +3527,7 @@ pub mod queue {
         let (i, queue) = parse_short_string.parse(i)?;
         let (i, flags) = parse_flags(
             i,
-            &["passive", "durable", "exclusive", "auto-delete", "nowait"],
+            &["passive", "durable", "exclusive", "auto_delete", "nowait"],
         )?;
         let (i, arguments) = parse_field_table.parse(i)?;
         Ok((
@@ -3820,7 +3820,7 @@ pub mod queue {
     pub fn parse_delete<I: ParsableInput>(i: I) -> ParserResult<I, Delete> {
         let (i, _) = parse_short_uint.parse(i)?;
         let (i, queue) = parse_short_string.parse(i)?;
-        let (i, flags) = parse_flags(i, &["if-unused", "if-empty", "nowait"])?;
+        let (i, flags) = parse_flags(i, &["if_unused", "if_empty", "nowait"])?;
         Ok((
             i,
             Delete {

--- a/protocol/templates/protocol.rs
+++ b/protocol/templates/protocol.rs
@@ -241,7 +241,7 @@ pub mod {{snake class.name}} {
         {{else}}
         let (i, {{#if argument.ignore_flags ~}}_{{else}}flags{{/if ~}}) = parse_flags(i, &[
             {{#each argument.flags as |flag| ~}}
-            "{{flag.name}}",
+            "{{snake flag.name}}",
             {{/each ~}}
         ])?;
         {{/if ~}}


### PR DESCRIPTION
Hello!

I'm building a prototype of 0.9.1 amqp server using `amq-protocol` and found issue with parsing frames with arguments contained dashes. It doesn't affect lapin as the client library.

Example:
```rust
#[test]
    fn test_parse_declare_queue_frame() {
        let frame = AMQPFrame::Method(
            1,
            AMQPClass::Queue(queue::AMQPMethod::Declare(queue::Declare {
                queue: "some_queue".into(),
                passive: true,
                durable: true,
                exclusive: true,
                auto_delete: true,
                nowait: true,
                arguments: Default::default(),
            })),
        );

        let mut buffer = vec![0u8; 30];

        assert!(gen_frame(&frame)(buffer.as_mut_slice().into()).is_ok());
        assert_eq!(parse_frame(buffer.as_slice()), Ok((&[][..], frame)));
    }
```
Output: 
```
assertion `left == right` failed
  left: Ok(([], Method(1, Queue(Declare(Declare { queue: ShortString("some_queue"), passive: true, durable: true, exclusive: true, auto_delete: false, nowait: true, arguments: FieldTable({}) })))))
 right: Ok(([], Method(1, Queue(Declare(Declare { queue: ShortString("some_queue"), passive: true, durable: true, exclusive: true, auto_delete: true, nowait: true, arguments: FieldTable({}) })))))
```
The source is serialized as `auto_delete: true` and parsed as `auto_delete: false`