### PR TITLE
Change so that FieldTable::insert returns self

### DIFF
--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -250,8 +250,9 @@ impl From<Vec<AMQPValue>> for FieldArray {
 
 impl FieldTable {
     /// Insert a new entry in the table
-    pub fn insert(&mut self, k: ShortString, v: AMQPValue) {
+    pub fn insert(&mut self, k: ShortString, v: AMQPValue) -> &mut Self {
         self.0.insert(k, v);
+        self
     }
 
     /// Check whether the table contains the given key


### PR DESCRIPTION
This is to make chained inserts easier, avoiding the need to create intermediate variables/blocks when creating inline FieldTable's 