### PR TITLE
Incompatibility with `tcp-stream:0.31`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "cfg-if",
  "executor-trait",
  "hickory-to-socket-addrs",
- "reactor-trait 2.7.0",
+ "reactor-trait",
  "tcp-stream",
  "tracing",
 ]
@@ -909,7 +909,7 @@ checksum = "b8bdfa866f521fc1b0e6e71d42b9c4277d36799d8b5f86da209d8234eeebf4ac"
 dependencies = [
  "async-trait",
  "hickory-resolver",
- "reactor-trait 2.7.0",
+ "reactor-trait",
  "tokio",
 ]
 
@@ -1715,19 +1715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reactor-trait"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca7ed32322a65b7d117313b73e6adef5ae225d71349a4d4330cd0a084dcd1a8"
-dependencies = [
- "async-trait",
- "executor-trait",
- "flume",
- "futures-core",
- "futures-io",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,9 +2179,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tcp-stream"
-version = "0.31.2"
+version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936a5fb21e17fe3e00892264ddcd8d9e6738d2436cda8d08c8293df68b663b3d"
+checksum = "282ebecea8280bce8b7a0695b5dc93a19839dd445cbba70d3e07c9f6e12c4653"
 dependencies = [
  "async-native-tls",
  "async-openssl",
@@ -2203,7 +2190,7 @@ dependencies = [
  "native-tls",
  "openssl",
  "p12-keystore",
- "reactor-trait 3.1.0",
+ "reactor-trait",
  "rustls-connector",
  "rustls-pemfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "cfg-if",
  "executor-trait",
  "hickory-to-socket-addrs",
- "reactor-trait",
+ "reactor-trait 2.7.0",
  "tcp-stream",
  "tracing",
 ]
@@ -909,7 +909,7 @@ checksum = "b8bdfa866f521fc1b0e6e71d42b9c4277d36799d8b5f86da209d8234eeebf4ac"
 dependencies = [
  "async-trait",
  "hickory-resolver",
- "reactor-trait",
+ "reactor-trait 2.7.0",
  "tokio",
 ]
 
@@ -1715,6 +1715,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "reactor-trait"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca7ed32322a65b7d117313b73e6adef5ae225d71349a4d4330cd0a084dcd1a8"
+dependencies = [
+ "async-trait",
+ "executor-trait",
+ "flume",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,9 +2192,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tcp-stream"
-version = "0.30.9"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282ebecea8280bce8b7a0695b5dc93a19839dd445cbba70d3e07c9f6e12c4653"
+checksum = "936a5fb21e17fe3e00892264ddcd8d9e6738d2436cda8d08c8293df68b663b3d"
 dependencies = [
  "async-native-tls",
  "async-openssl",
@@ -2190,7 +2203,7 @@ dependencies = [
  "native-tls",
  "openssl",
  "p12-keystore",
- "reactor-trait",
+ "reactor-trait 3.1.0",
  "rustls-connector",
  "rustls-pemfile",
 ]

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -57,7 +57,6 @@ features = ["reactor-trait"]
 [dependencies.tcp-stream]
 version = "0.30.9"
 default-features = false
-features = ["futures"]
 
 [dependencies.tracing]
 version = "^0.1"

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name          = "amq-protocol-tcp"
-description   = "AMQP URI TCP connection handling"
+name = "amq-protocol-tcp"
+description = "AMQP URI TCP connection handling"
 documentation = "https://docs.rs/amq-protocol-tcp"
 
 authors.workspace = true
@@ -16,21 +16,28 @@ version.workspace = true
 name = "amq_protocol_tcp"
 
 [features]
-default                   = ["rustls"]
-hickory-dns               = ["dep:hickory-to-socket-addrs"]
+default = ["rustls"]
+hickory-dns = ["dep:hickory-to-socket-addrs"]
 
-native-tls                = ["tcp-stream/native-tls-futures"]
-openssl                   = ["tcp-stream/openssl-futures"]
-rustls                    = ["rustls-native-certs", "rustls--aws_lc_rs"]
-rustls-native-certs       = ["rustls-common", "tcp-stream/rustls-native-certs"]
-rustls-webpki-roots-certs = ["rustls-common", "tcp-stream/rustls-webpki-roots-certs"]
-rustls-common             = ["tcp-stream/rustls-futures"]
-vendored-openssl          = ["tcp-stream/vendored-openssl"]
+native-tls = ["tcp-stream/native-tls-futures"]
+openssl = ["tcp-stream/openssl-futures"]
+rustls = ["rustls-native-certs", "rustls--aws_lc_rs"]
+rustls-native-certs = ["rustls-common", "tcp-stream/rustls-native-certs"]
+rustls-webpki-roots-certs = [
+    "rustls-common",
+    "tcp-stream/rustls-webpki-roots-certs",
+]
+rustls-common = ["tcp-stream/rustls-futures"]
+vendored-openssl = ["tcp-stream/vendored-openssl"]
 
 # rustls crypto providers. Choose at least one. Otherwise, runtime errors.
 # See https://docs.rs/rustls/latest/rustls/#crate-features. for more info
-rustls--aws_lc_rs         = ["tcp-stream/rustls--aws_lc_rs"] # default, but doesn't build everywhere
-rustls--ring              = ["tcp-stream/rustls--ring"] # more compatible, (e.g., easily builds on Windows)
+rustls--aws_lc_rs = [
+    "tcp-stream/rustls--aws_lc_rs",
+] # default, but doesn't build everywhere
+rustls--ring = [
+    "tcp-stream/rustls--ring",
+] # more compatible, (e.g., easily builds on Windows)
 
 [dependencies]
 async-trait = "^0.1.42"
@@ -40,7 +47,7 @@ reactor-trait = "^2.7"
 
 [dependencies.amq-protocol-uri]
 version = "=8.3.0"
-path    = "../uri"
+path = "../uri"
 
 [dependencies.hickory-to-socket-addrs]
 version = "^1.3"
@@ -48,12 +55,12 @@ optional = true
 features = ["reactor-trait"]
 
 [dependencies.tcp-stream]
-version          = "^0.31.2"
+version = "0.30.9"
 default-features = false
 features = ["futures"]
 
 [dependencies.tracing]
-version          = "^0.1"
+version = "^0.1"
 default-features = false
 
 [badges]

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -48,8 +48,9 @@ optional = true
 features = ["reactor-trait"]
 
 [dependencies.tcp-stream]
-version          = "^0.30.9"
+version          = "^0.31.2"
 default-features = false
+features = ["futures"]
 
 [dependencies.tracing]
 version          = "^0.1"


### PR DESCRIPTION
The current `tcp-stream` semver selector will allow for breaking changes to be automatically accepted across `0.x` version bumps. The latest `tcp-stream:0.31.2` includes changes that are incompatible with this library.